### PR TITLE
Allow playbook to override prometheus config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ prometheus_volume_source: /srv/prometheus-data
 prometheus_volume_target: /prometheus-data
 prometheus_volume_mountinstruction: "{{prometheus_volume_source}}:{{ prometheus_volume_target }}"
 prometheus_container_name: prometheus
+prometheus_config_template: prometheus.yml.j2
 prometheus_rule_file_name: rule_file.yml
 prometheus_rule_file_location: "{{ prometheus_volume_target }}/{{ prometheus_rule_file_name }}"
 prometheus_commandline_args:

--- a/tasks/install_prometheus.yml
+++ b/tasks/install_prometheus.yml
@@ -14,7 +14,7 @@
 - name: Copy config file
   become: yes
   template:
-        src: prometheus.yml.j2
+        src: "{{ prometheus_config_template }}"
         dest: "{{ prometheus_volume_source}}/prometheus.yml"
         owner: root
         mode: 0666 


### PR DESCRIPTION
this resolves https://github.com/AlexisLessard/docker-prometheus/issues/3
Allowing others to set the template name means that playbooks can alter the template name and thereby inject their own template. In this case, that means that we can add more targets.